### PR TITLE
Feat: Add filter to hook functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ vscode-telert/.eslintcache
 config.json
 .internaldocs
 .reddit_post.txt
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.8 (2026-01-12)
+- Add hook message filtering with wildcard patterns
+  - New `telert hook-filter` command to manage filters (add/remove/list/clear)
+  - Filters use shell-style wildcards (*, ?, [seq]) to match commands
+  - Filtered commands are silenced and won't trigger notifications
+
 ## 0.2.7 (2025-10-18)
 - Add zsh support to hook functionality
 

--- a/README.es.md
+++ b/README.es.md
@@ -7,7 +7,7 @@
   <img src="https://github.com/navig-me/telert/raw/main/telert.png" alt="telert logo" width="150">
 </p>
 
-**Versión 0.2.7**
+**Versión 0.2.8**
 
 [![GitHub Stars](https://img.shields.io/github/stars/navig-me/telert?style=social)](https://github.com/navig-me/telert/stargazers)
 [![PyPI version](https://img.shields.io/pypi/v/telert)](https://pypi.org/project/telert/)
@@ -77,6 +77,28 @@ echo 'eval "$(telert hook -l 30)"' >> ~/.bashrc
 # Agregar a tu .zshrc (usuarios de Zsh)
 echo 'eval "$(telert hook -l 30)"' >> ~/.zshrc
 ```
+
+**Filtrar mensajes del hook:**
+
+Puedes silenciar notificaciones para comandos específicos usando patrones con comodines:
+
+```bash
+# Agregar filtros para silenciar comandos comunes
+telert hook-filter add "cd *"        # Silenciar todos los comandos cd con argumentos
+telert hook-filter add "ls*"         # Silenciar ls, lsof, lsblk, etc.
+telert hook-filter add "git status"  # Silenciar comando exacto
+
+# Listar filtros configurados
+telert hook-filter list
+
+# Eliminar un filtro
+telert hook-filter remove "ls*"
+
+# Limpiar todos los filtros
+telert hook-filter clear
+```
+
+Los filtros usan comodines estilo shell: `*` coincide con cualquier secuencia, `?` coincide con cualquier carácter individual, `[seq]` coincide con cualquier carácter en seq.
 
 ## 🚦 Monitorización
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -7,7 +7,7 @@
   <img src="https://github.com/navig-me/telert/raw/main/telert.png" alt="telert logo" width="150">
 </p>
 
-**संस्करण 0.2.7**
+**संस्करण 0.2.8**
 
 [![GitHub Stars](https://img.shields.io/github/stars/navig-me/telert?style=social)](https://github.com/navig-me/telert/stargazers)
 [![PyPI version](https://img.shields.io/pypi/v/telert)](https://pypi.org/project/telert/)
@@ -77,6 +77,28 @@ echo 'eval "$(telert hook -l 30)"' >> ~/.bashrc
 # अपनी .zshrc में जोड़ें (Zsh उपयोगकर्ता)
 echo 'eval "$(telert hook -l 30)"' >> ~/.zshrc
 ```
+
+**हुक संदेशों को फ़िल्टर करना:**
+
+आप वाइल्डकार्ड पैटर्न का उपयोग करके विशिष्ट कमांड के नोटिफिकेशन को साइलेंस कर सकते हैं:
+
+```bash
+# सामान्य कमांड को साइलेंस करने के लिए फ़िल्टर जोड़ें
+telert hook-filter add "cd *"        # सभी cd कमांड (आर्ग्युमेंट के साथ) साइलेंस करें
+telert hook-filter add "ls*"         # ls, lsof, lsblk आदि साइलेंस करें
+telert hook-filter add "git status"  # सटीक कमांड साइलेंस करें
+
+# कॉन्फ़िगर किए गए फ़िल्टर की सूची देखें
+telert hook-filter list
+
+# फ़िल्टर हटाएं
+telert hook-filter remove "ls*"
+
+# सभी फ़िल्टर साफ़ करें
+telert hook-filter clear
+```
+
+फ़िल्टर शेल-स्टाइल वाइल्डकार्ड का उपयोग करते हैं: `*` किसी भी अनुक्रम से मेल खाता है, `?` किसी भी एकल वर्ण से मेल खाता है, `[seq]` seq में किसी भी वर्ण से मेल खाता है।
 
 ## 🚦 मॉनिटरिंग
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://github.com/navig-me/telert/raw/main/telert.png" alt="telert logo" width="150">
 </p>
 
-**Version 0.2.7**
+**Version 0.2.8**
 
 [![PyPI Downloads](https://static.pepy.tech/badge/telert)](https://pepy.tech/projects/telert)
 [![GitHub Stars](https://img.shields.io/github/stars/navig-me/telert?style=social)](https://github.com/navig-me/telert/stargazers)
@@ -354,7 +354,7 @@ Configuration is stored in `~/.config/telert/config.json` and can be overridden 
 |----------------|--------------|---------|
 | **Run**        | Wraps a command, times it, sends notification with exit code. | `telert run --label "RSYNC" rsync -a /src /dst` |
 | **Filter**     | Reads from stdin so you can pipe command output. | `long_job \| telert "compile done"` |
-| **Hook**       | Generates a Bash snippet so **every** command > *N* seconds notifies automatically. | `eval "$(telert hook -l 30)"` |
+| **Hook**       | Generates a Bash/Zsh snippet so **every** command > *N* seconds notifies automatically. Supports wildcard filters to silence specific commands. | `eval "$(telert hook -l 30)"` |
 | **Monitor**    | Watches processes, log files, and network endpoints. | `telert monitor process --name "nginx" --notify-on stop` |
 | **Send**       | Low-level "send arbitrary text" helper. | `telert send --provider slack "Build complete"` |
 | **Python API** | Use directly in Python code with context managers and decorators. | `from telert import telert, send, notify` |
@@ -544,6 +544,28 @@ echo 'eval "$(telert hook -l 30)"' >> ~/.bashrc
 # Add to your .zshrc (Zsh users)
 echo 'eval "$(telert hook -l 30)"' >> ~/.zshrc
 ```
+
+**Filtering hook messages:**
+
+You can silence notifications for specific commands using wildcard patterns:
+
+```bash
+# Add filters to silence common commands
+telert hook-filter add "cd *"        # Silence all cd commands with arguments
+telert hook-filter add "ls*"         # Silence ls, lsof, lsblk, etc.
+telert hook-filter add "git status"  # Silence exact command
+
+# List configured filters
+telert hook-filter list
+
+# Remove a filter
+telert hook-filter remove "ls*"
+
+# Clear all filters
+telert hook-filter clear
+```
+
+Filters use shell-style wildcards: `*` matches any sequence, `?` matches any single character, `[seq]` matches any character in seq.
 
 #### CLI Help
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
   <img src="https://github.com/navig-me/telert/raw/main/telert.png" alt="telert logo" width="150">
 </p>
 
-**版本 0.2.7**
+**版本 0.2.8**
 
 [![GitHub Stars](https://img.shields.io/github/stars/navig-me/telert?style=social)](https://github.com/navig-me/telert/stargazers)
 [![PyPI version](https://img.shields.io/pypi/v/telert)](https://pypi.org/project/telert/)
@@ -77,6 +77,28 @@ echo 'eval "$(telert hook -l 30)"' >> ~/.bashrc
 # 添加到你的 .zshrc（Zsh 用户）
 echo 'eval "$(telert hook -l 30)"' >> ~/.zshrc
 ```
+
+**过滤钩子消息：**
+
+你可以使用通配符模式来静默特定命令的通知：
+
+```bash
+# 添加过滤器以静默常见命令
+telert hook-filter add "cd *"        # 静默所有带参数的 cd 命令
+telert hook-filter add "ls*"         # 静默 ls、lsof、lsblk 等
+telert hook-filter add "git status"  # 静默特定命令
+
+# 列出已配置的过滤器
+telert hook-filter list
+
+# 移除过滤器
+telert hook-filter remove "ls*"
+
+# 清除所有过滤器
+telert hook-filter clear
+```
+
+过滤器使用 shell 风格的通配符：`*` 匹配任意序列，`?` 匹配任意单个字符，`[seq]` 匹配 seq 中的任意字符。
 
 ## 监控功能
 

--- a/packaging/docker/server.py
+++ b/packaging/docker/server.py
@@ -21,7 +21,7 @@ has_static = static_dir.exists()
 app = FastAPI(
     title="Telert API",
     description="Send notifications from HTTP requests to various messaging services",
-    version="0.2.7",
+    version="0.2.8",
 )
 
 # Serve static files if directory exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telert"
-version = "0.2.7"
+version = "0.2.8"
 description = "Ultimate command monitoring & notification system: Telegram, Slack, Discord, Teams, Pushover, Email, desktop & more. Monitor Python code and CLI tasks with context managers, decorators, and webhooks."
 authors = [{ name = "Mihir Khandekar", email = "mihirkhandekar@gmail.com" }]
 license = "MIT"

--- a/telert/__init__.py
+++ b/telert/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "set_default_providers",
     "list_providers",
 ]
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
 from telert.api import (
     configure,

--- a/telert/cli.py
+++ b/telert/cli.py
@@ -622,6 +622,57 @@ def do_status(a):
             sys.exit(f"❌ Failed to send message: {str(e)}")
 
 
+def do_hook_filter(a):
+    """Manage hook message filters."""
+    config = MessagingConfig()
+
+    if a.action == "add":
+        if not a.pattern:
+            sys.exit("❌ You must specify a pattern to add")
+        if config.add_hook_filter(a.pattern):
+            print(f"✔ Filter added: {a.pattern}")
+        else:
+            print(f"Filter already exists: {a.pattern}")
+
+    elif a.action == "remove":
+        if not a.pattern:
+            sys.exit("❌ You must specify a pattern to remove")
+        if config.remove_hook_filter(a.pattern):
+            print(f"✔ Filter removed: {a.pattern}")
+        else:
+            sys.exit(f"❌ Filter not found: {a.pattern}")
+
+    elif a.action == "list":
+        filters = config.get_hook_filters()
+        if not filters:
+            print("No hook filters configured.")
+        else:
+            print("Hook filters:")
+            for f in filters:
+                print(f"  {f}")
+
+    elif a.action == "clear":
+        config.clear_hook_filters()
+        print("✔ All hook filters cleared.")
+
+
+def do_hook_check_filter(a):
+    """Check if a command matches any hook filter (for shell hook use)."""
+    import fnmatch
+
+    config = MessagingConfig()
+    filters = config.get_hook_filters()
+    command = a.command
+
+    for pattern in filters:
+        if fnmatch.fnmatch(command, pattern):
+            # Match found - exit with 0 (filtered)
+            sys.exit(0)
+
+    # No match - exit with 1 (not filtered)
+    sys.exit(1)
+
+
 def do_hook(a):
     """Generate a shell hook for command notifications."""
     shell = a.shell or os.path.basename(os.environ.get("SHELL", "bash"))
@@ -645,7 +696,10 @@ def do_hook(a):
                             local end=$EPOCHSECONDS
                             local duration=$((end - __TELERT_START__))
                             if (( duration >= {threshold} )); then
-                                telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((duration/60)) $((duration%60)))"
+                                # Check if command matches any filter
+                                if ! telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then
+                                    telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((duration/60)) $((duration%60)))"
+                                fi
                             fi
                             unset __TELERT_START__
                         fi
@@ -681,7 +735,10 @@ def do_hook(a):
                     local end=$EPOCHSECONDS
                     local duration=$((end - __TELERT_START__))
                     if (( duration >= {threshold} )); then
-                        telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((duration/60)) $((duration%60)))"
+                        # Check if command matches any filter
+                        if ! telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then
+                            telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((duration/60)) $((duration%60)))"
+                        fi
                     fi
                     unset __TELERT_START__
                     unset __TELERT_CMD__
@@ -694,7 +751,7 @@ def do_hook(a):
     else:  # Default to bash
         hook_script = textwrap.dedent(f"""
             telert_preexec() {{{{ export __TELERT_CMD__="$BASH_COMMAND"; export TELERT_START=$EPOCHSECONDS; }}}}
-            telert_precmd()  {{{{ local st=$?; if [[ -n "$TELERT_START" ]]; then local d=$((EPOCHSECONDS-TELERT_START)); if (( d >= {threshold} )); then telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((d/60)) $((d%60)))"; fi; unset TELERT_START; fi; }}}}
+            telert_precmd()  {{{{ local st=$?; if [[ -n "$TELERT_START" ]]; then local d=$((EPOCHSECONDS-TELERT_START)); if (( d >= {threshold} )) && ! telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((d/60)) $((d%60)))"; fi; unset TELERT_START; fi; }}}}
             trap 'telert_preexec' DEBUG
             PROMPT_COMMAND="telert_precmd${{{{PROMPT_COMMAND:+;}}}}$PROMPT_COMMAND"
         """).strip()
@@ -1768,6 +1825,25 @@ def main():
         help="specify the shell type (default: auto-detect from $SHELL)",
     )
     hk.set_defaults(func=do_hook)
+
+    # hook-filter
+    hf = sp.add_parser("hook-filter", help="manage hook message filters (wildcard patterns)")
+    hf.add_argument(
+        "action",
+        choices=["add", "remove", "list", "clear"],
+        help="action to perform",
+    )
+    hf.add_argument(
+        "pattern",
+        nargs="?",
+        help="wildcard pattern to filter (e.g., 'cd *', 'ls*', 'git status')",
+    )
+    hf.set_defaults(func=do_hook_filter)
+
+    # hook-check-filter (internal command for shell hook use)
+    hcf = sp.add_parser("hook-check-filter", help="check if command matches a filter (internal)")
+    hcf.add_argument("command", help="command to check against filters")
+    hcf.set_defaults(func=do_hook_check_filter)
 
     # send
     sd = sp.add_parser("send", help="send arbitrary text")

--- a/telert/cli.py
+++ b/telert/cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import traceback
 import argparse
+import fnmatch
 import os
 import subprocess
 import sys
@@ -658,19 +659,17 @@ def do_hook_filter(a):
 
 def do_hook_check_filter(a):
     """Check if a command matches any hook filter (for shell hook use)."""
-    import fnmatch
-
     config = MessagingConfig()
     filters = config.get_hook_filters()
     command = a.command
 
     for pattern in filters:
         if fnmatch.fnmatch(command, pattern):
-            # Match found - exit with 0 (filtered)
-            sys.exit(0)
+            # Match found - exit with 1 (filtered, suppress notification)
+            sys.exit(1)
 
-    # No match - exit with 1 (not filtered)
-    sys.exit(1)
+    # No match - exit with 0 (not filtered, allow notification)
+    sys.exit(0)
 
 
 def do_hook(a):
@@ -697,7 +696,7 @@ def do_hook(a):
                             local duration=$((end - __TELERT_START__))
                             if (( duration >= {threshold} )); then
                                 # Check if command matches any filter
-                                if ! telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then
+                                if telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then
                                     telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((duration/60)) $((duration%60)))"
                                 fi
                             fi
@@ -736,7 +735,7 @@ def do_hook(a):
                     local duration=$((end - __TELERT_START__))
                     if (( duration >= {threshold} )); then
                         # Check if command matches any filter
-                        if ! telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then
+                        if telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then
                             telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((duration/60)) $((duration%60)))"
                         fi
                     fi
@@ -751,7 +750,7 @@ def do_hook(a):
     else:  # Default to bash
         hook_script = textwrap.dedent(f"""
             telert_preexec() {{{{ export __TELERT_CMD__="$BASH_COMMAND"; export TELERT_START=$EPOCHSECONDS; }}}}
-            telert_precmd()  {{{{ local st=$?; if [[ -n "$TELERT_START" ]]; then local d=$((EPOCHSECONDS-TELERT_START)); if (( d >= {threshold} )) && ! telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((d/60)) $((d%60)))"; fi; unset TELERT_START; fi; }}}}
+            telert_precmd()  {{{{ local st=$?; if [[ -n "$TELERT_START" ]]; then local d=$((EPOCHSECONDS-TELERT_START)); if (( d >= {threshold} )) && telert hook-check-filter "$__TELERT_CMD__" 2>/dev/null; then telert send "$__TELERT_CMD__ exited with $st in $(printf '%dm%02ds' $((d/60)) $((d%60)))"; fi; unset TELERT_START; fi; }}}}
             trap 'telert_preexec' DEBUG
             PROMPT_COMMAND="telert_precmd${{{{PROMPT_COMMAND:+;}}}}$PROMPT_COMMAND"
         """).strip()

--- a/telert/messaging.py
+++ b/telert/messaging.py
@@ -339,6 +339,8 @@ class MessagingConfig:
         Returns:
             True if added, False if already exists
         """
+        if not pattern or not pattern.strip():
+            return False
         filters = self.get_hook_filters()
         if pattern in filters:
             return False

--- a/telert/messaging.py
+++ b/telert/messaging.py
@@ -326,6 +326,49 @@ class MessagingConfig:
         self.set_default_providers([provider])
         self.save()
 
+    def get_hook_filters(self) -> List[str]:
+        """Get the list of hook message filters (wildcard patterns)."""
+        return self._config.get("hook_filters", [])
+
+    def add_hook_filter(self, pattern: str) -> bool:
+        """Add a hook message filter pattern.
+
+        Args:
+            pattern: Wildcard pattern to filter messages (e.g., "cd *", "ls*")
+
+        Returns:
+            True if added, False if already exists
+        """
+        filters = self.get_hook_filters()
+        if pattern in filters:
+            return False
+        filters.append(pattern)
+        self._config["hook_filters"] = filters
+        self.save()
+        return True
+
+    def remove_hook_filter(self, pattern: str) -> bool:
+        """Remove a hook message filter pattern.
+
+        Args:
+            pattern: The exact pattern to remove
+
+        Returns:
+            True if removed, False if not found
+        """
+        filters = self.get_hook_filters()
+        if pattern not in filters:
+            return False
+        filters.remove(pattern)
+        self._config["hook_filters"] = filters
+        self.save()
+        return True
+
+    def clear_hook_filters(self):
+        """Remove all hook message filters."""
+        self._config["hook_filters"] = []
+        self.save()
+
 
 def prepare_telegram_html(message: str) -> str:
     """

--- a/vscode-telert/package.json
+++ b/vscode-telert/package.json
@@ -2,7 +2,7 @@
   "name": "telert-vscode",
   "displayName": "Telert - Alerts and Monitoring for your Terminal Commands and Python Functions",
   "description": "Python function monitoring, terminal command alerts, and notifications for your code execution",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publisher": "Navig",
   "author": "Mihir Khandekar <mihirkhandekar@gmail.com>",
   "engines": {


### PR DESCRIPTION
Added feature to use wildcard filters in order to filter out hook messages.

By default, I want to know when any long-running command finishes.  However, there are some that I would like to exclude from the alerts as they are not important enough to be notified.  In order to reduce the noise, I (w/ Claude) implemented a filter that applies to hook functionality only.

New functionality allows adding, removing, listing and clearing the hook filters.

I've selected wildcards over regex for ease of use, assuming that most use cases are straight forward.

Feedback is welcome.